### PR TITLE
CMake Version Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 
 #
 # Here we check whether mio is being configured in isolation or as a component


### PR DESCRIPTION
The `cmake_minimum_required(VERSION <ver>)` directive will give a deprecation warning if `<ver>` is less than 3.10. The `CMakeLists.txt` has been updated to require 3.15.